### PR TITLE
Fix typo to resolve goreleaser/goreleaser#83

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,12 +1,4 @@
 # Build customization
 build:
-  main: ./main.go
-  ldflags: -s -w
-  goos:
-    - darwin
-    - linux
   goarch:
     - amd64
-  files:
-    - README.md
-    - LICENSE

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -2,7 +2,7 @@
 build:
   main: ./main.go
   ldflags: -s -w
-  gogs:
+  goos:
     - darwin
     - linux
   goarch:


### PR DESCRIPTION
And also simplifying `goreleaser.yml` config.

You can find an example configuration including the default values here:
https://github.com/goreleaser/goreleaser/blob/master/goreleaser.example.yml